### PR TITLE
Added missing import for magic

### DIFF
--- a/rules/compressed.yar
+++ b/rules/compressed.yar
@@ -2,6 +2,7 @@
 Compressed file classification YARA rules
 by Vaccinator Security (vaccinator.tech)
 */
+import "magic"
 
 // https://github.com/Xumeiquer/yara-forensics
 


### PR DESCRIPTION
While testing locally with yara, no errors were being thrown, while compiling with internal tool it would crash.